### PR TITLE
Fix typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# LINKR MINIFIY URLS
+# LINKR - MINIFY URLS
 
-A small app to handle minifiying of URLs :)
+A small app to handle minifying of URLs :)
 
 (work in progress)


### PR DESCRIPTION
The word "minify" is spelled incorrectly.

> https://www.wordnik.com/words/minify
