### PR TITLE
use better regex pattern for urls

### DIFF
--- a/api/routes/redirects.js
+++ b/api/routes/redirects.js
@@ -167,7 +167,11 @@ exports.remove = function(req, res){
 }*/
 
 function validateURL(url){
-	var regex = new RegExp(/([https|http]:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]\/*)/);
+	/*
+		regex pattern taken from http://stackoverflow.com/a/3809435/3909521
+	*/
+	var expression = /[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/;
+	var regex = new RegExp(expression);
 	if(url.match(regex)){
 		return url
 	}


### PR DESCRIPTION
The old pattern did not allow an URL like "http://google.de" although it would be a valid one.
The new regex taken from http://stackoverflow.com/a/3809435/3909521
accounts for that.
